### PR TITLE
ログインユーザー情報をDynamoDBに送信

### DIFF
--- a/.graphqlconfig.yml
+++ b/.graphqlconfig.yml
@@ -1,0 +1,15 @@
+projects:
+  frontenddeveloperres:
+    schemaPath: amplify/backend/api/frontenddeveloperres/build/schema.graphql
+    includes:
+      - src/graphql/**/*.ts
+    excludes:
+      - ./amplify/**
+    extensions:
+      amplify:
+        codeGenTarget: typescript
+        generatedFileName: src/API.ts
+        docsFilePath: src/graphql
+        region: ap-northeast-1
+        apiId: null
+        maxDepth: 2

--- a/src/components/api/auth.ts
+++ b/src/components/api/auth.ts
@@ -1,0 +1,23 @@
+import Auth from '@aws-amplify/auth'
+import { API, graphqlOperation }  from 'aws-amplify'
+import { createUser } from "@/src/graphql/mutations"
+
+export const fetchAuthUser = async () => {
+  try {
+    return await Auth.currentAuthenticatedUser()
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const createUserInDynamoDB = async (userInfo: any) => {
+  try {
+    await API.graphql(graphqlOperation(createUser, {input: userInfo}))
+    console.log('ユーザーの作成に成功しました');
+  } catch (error: any) {
+    if (error.errors[0].errorType === 'DynamoDB:ConditionalCheckFailedException') {
+      console.log('すでにユーザーが作成されています')
+    }
+    console.error(error)
+  }
+}

--- a/src/components/api/index.ts
+++ b/src/components/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./auth"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,7 +22,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     const createUserField = async () => {
       const user = await fetchAuthUser()
       const userInfo: UserInfo = {
-        id: user.username,
+        id: user.attributes.sub,
         name: user.attributes.name,
         email: user.attributes.email,
         profileImagePath: user.attributes.picture,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react'
 import '@/styles/globals.scss'
 import type { AppProps } from 'next/app'
-import Amplify, { API, graphqlOperation }  from 'aws-amplify'
-import Auth from '@aws-amplify/auth'
+import Amplify from 'aws-amplify'
+import { fetchAuthUser, createUserInDynamoDB } from "@/src/components/api"
+import { UserInfo } from "@/src/types"
 import config from '../aws-exports'
-import { createUser } from "../graphql/mutations"
 Amplify.configure(config)
 
 if (typeof window !== 'undefined') {
@@ -17,10 +17,11 @@ if (typeof window !== 'undefined') {
 }
 
 function MyApp({ Component, pageProps }: AppProps) {
+  // Google認証したユーザー情報をDynamoDBに送信
   useEffect(() => {
     const createUserField = async () => {
-      const user = await Auth.currentAuthenticatedUser()
-      const userInfo = {
+      const user = await fetchAuthUser()
+      const userInfo: UserInfo = {
         id: user.username,
         name: user.attributes.name,
         email: user.attributes.email,
@@ -28,8 +29,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         progressRate: 0,
         resourcesCount: 0,
       }
-      await API.graphql(graphqlOperation(createUser, {input: userInfo}))
-      console.log('ユーザーの作成に成功しました');
+      await createUserInDynamoDB(userInfo)
     }
     createUserField()
   }, [])

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,10 @@
+import { useEffect } from 'react'
 import '@/styles/globals.scss'
 import type { AppProps } from 'next/app'
-import Amplify from 'aws-amplify'
+import Amplify, { API, graphqlOperation }  from 'aws-amplify'
+import Auth from '@aws-amplify/auth'
 import config from '../aws-exports'
+import { createUser } from "../graphql/mutations"
 Amplify.configure(config)
 
 if (typeof window !== 'undefined') {
@@ -14,6 +17,23 @@ if (typeof window !== 'undefined') {
 }
 
 function MyApp({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    const createUserField = async () => {
+      const user = await Auth.currentAuthenticatedUser()
+      const userInfo = {
+        id: user.username,
+        name: user.attributes.name,
+        email: user.attributes.email,
+        profileImagePath: user.attributes.picture,
+        progressRate: 0,
+        resourcesCount: 0,
+      }
+      await API.graphql(graphqlOperation(createUser, {input: userInfo}))
+      console.log('ユーザーの作成に成功しました');
+    }
+    createUserField()
+  }, [])
+
   return <Component {...pageProps} />
 }
 export default MyApp

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,11 @@
+export type UserInfo = {
+  id: string,
+  name: string,
+  email: string,
+  profileImagePath: string,
+  progressRate: number,
+  resourcesCount: number,
+  posts?: []
+  createdAt?: string,
+  updatedAt?: string,
+}


### PR DESCRIPTION
## 内容
- googleログイン後localhost:3000にリダイレクトされるのでそのタイミングでdynamoDBにユーザー情報を送信
- 現状localhost:3000にアクセスするたびにdynamoDBにユーザー情報の送信を試みている
- すでにdynamoDBにユーザー登録済みの場合はエラーが出るので問題ないと思う
- けど毎回dynamoDBにユーザー情報を送信するのは綺麗じゃないかも

- あとユーザーIDはgoogleのauthproviderから取得した`google_109102606898136542770`みたいな文字列になっている
- `google_`の部分いらない気がするけど数字だけ抽出する実装までは飽きてしまったのでやってない