### PR TITLE
fix:認証系のバグ修正

### DIFF
--- a/src/components/model/auth/Auth.tsx
+++ b/src/components/model/auth/Auth.tsx
@@ -26,7 +26,7 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
         let authUser = await fetchCurrentUser(userInfo.id)
         // 初回ログインか
-        if (!authUser) {
+        if (!authUser?.data?.getUser) {
           await createUserInDynamoDB(userInfo)
           authUser = await fetchCurrentUser(userInfo.id)
         }
@@ -35,7 +35,7 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
       // TODO: ここにリダイレクト処理を入れたい
     })()
-  }, [])
+  }, [currentUser])
 
   return (
     <AuthContext.Provider


### PR DESCRIPTION
## 修正内容

- リロードすると、認証情報が　Providerから消える
 → currentUserをトリガーにすることで、currentUserが空になったときに値を入れ直すように修正
- 初回ログイン時に　ProviderにcurrentUserがundefinedになる
 →if(!authUser)だと、初回ログイン時でもfalseになる。なので、初回ログイン時のみtrueになるように
if (!authUser?.data?.getUser)に変更